### PR TITLE
Fix perms CF works

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -148,13 +148,7 @@ Resources:
         Statement:
         # S3
         - Effect: Allow
-          Action:
-          - s3:CreateBucket
-          - s3:ListBucket
-          - s3:PutObject
-          - s3:GetObject
-          - s3:DeleteObject
-          - s3:PutObjectAcl
+          Action: "s3:*"
           Resource: "*"
         # CFront
         - Effect: Allow
@@ -170,6 +164,7 @@ Resources:
           - cloudfront:CreateInvalidation
           - cloudfront:GetInvalidation
           - cloudfront:ListInvalidations
+          - cloudfront:TagResource
           - elasticloadbalancing:DescribeLoadBalancers
           - iam:ListServerCertificates,
           - sns:ListSubscriptionsByTopic


### PR DESCRIPTION
For CF to create a bucket it somehow needs something on top of s3:CreateBucket. Tried a bunch to no avail to get the portal deployer to create, no dice. So s3:* it is... 
Also needs cloudfront:tagResource to create the CF distribution
Porting online changes to script to keep in line.